### PR TITLE
Fix security config for local API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Logistics App
+
+This is a simple Spring Boot project for managing shipments and users.
+
+## Building and Running
+
+Ensure you have JDK 17 and Maven installed. Then run:
+
+```bash
+./mvnw spring-boot:run
+```
+
+The application starts on `http://localhost:8080`.
+
+## API Endpoints
+
+- `POST /api/auth/register` — register a new user.
+- `POST /api/auth/login` — authenticate a user (returns a mock JWT token).
+- `POST /api/shipments` — create a shipment.
+- `GET /api/shipments` — list all shipments.
+
+Security is currently disabled, so the endpoints are accessible without authentication.

--- a/src/main/java/com/roy/logistics_app/config/SecurityConfig.java
+++ b/src/main/java/com/roy/logistics_app/config/SecurityConfig.java
@@ -4,11 +4,21 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 
 @Configuration
 public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+        return http.build();
     }
 }


### PR DESCRIPTION
## Summary
- disable all security rules to simplify local testing
- add a README with instructions and endpoint list

## Testing
- `./mvnw -q test` *(fails: Failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68617baffed483278f973a33f487374f